### PR TITLE
Pin apache-libcloud to <3.0.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v0.1.3
+
+* Pinned libcloud version to <3.0.0 to maintain Python 2 compatibility
+
+## v0.1.2
+
+* Update st2actions import path
+
 ## v0.1.1
 
 * Added example configuration

--- a/pack.yaml
+++ b/pack.yaml
@@ -6,6 +6,6 @@ keywords:
   - cloud
   - load balancers
   - dimension data
-version: 0.1.2
+version: 0.1.3
 author : Anthony Shaw
 email : anthony.shaw@dimensiondata.com

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
--e git+https://github.com/apache/libcloud@trunk#egg=apache-libcloud
+apache-libcloud<3.0.0


### PR DESCRIPTION
Should fix recent CI failures:
https://circleci.com/gh/StackStorm-Exchange/stackstorm-dimensiondata/136